### PR TITLE
Fix Unicode value parsing

### DIFF
--- a/data/json/test3.jsn
+++ b/data/json/test3.jsn
@@ -1,0 +1,1 @@
+{"chilllllllllllllllllllllllld":"Niñññññññññññññññññññññññño","child-jp":"子供","child":"Niño"}

--- a/data/smile/test3.smile
+++ b/data/smile/test3.smile
@@ -1,0 +1,3 @@
+:)
+��chilllllllllllllllllllllllld�Niñññññññññññññññññññññññño�child-jp�子供�child�Niño�
+

--- a/lib/decode.c
+++ b/lib/decode.c
@@ -180,12 +180,12 @@ int smile_decode(s_stream *strm)
             } else if (BYTE() >= 0x80 && BYTE() <= 0x9F) {
                 // Tiny Unicode
                 // 5 LSB used to indicate _byte_ lengths from 2 to 33
-                smile_value_length = (BYTE() & 0x1F) + 1;
+                smile_value_length = (BYTE() & 0x1F) + 2;
                 COPY_VALUE_STRING();
             } else if (BYTE() >= 0xA0 && BYTE() <= 0xBF) {
                 // Small Unicode
                 // 5 LSB used to indicate _byte_ lengths from 34 to 65
-                smile_value_length = (BYTE() & 0x1F) + 33;
+                smile_value_length = (BYTE() & 0x1F) + 34;
                 COPY_VALUE_STRING();
             } else if (BYTE() >= 0xC0 && BYTE() <= 0xDF) {
                 // Small integers

--- a/test/test.php
+++ b/test/test.php
@@ -29,7 +29,7 @@ function test_one_file($json_filename, $smile_filename) {
 }
 
 $files = array('json-org-sample1', 'json-org-sample2', 'json-org-sample3', 'json-org-sample4', 'json-org-sample5',
-               'numbers-int-4k', 'numbers-int-64k', 'test1', 'test2');
+               'numbers-int-4k', 'numbers-int-64k', 'test1', 'test2', 'test3');
 
 foreach ($files as $file) {
   test_one_File("$file.jsn", "$file.smile");

--- a/test/test.rb
+++ b/test/test.rb
@@ -26,7 +26,7 @@ def test_one_file(json_filename, smile_filename)
 end
 
 files = ['json-org-sample1', 'json-org-sample2', 'json-org-sample3', 'json-org-sample4', 'json-org-sample5',
-         'numbers-int-4k', 'numbers-int-64k', 'test1', 'test2'];
+         'numbers-int-4k', 'numbers-int-64k', 'test1', 'test2', 'test3'];
 
 files.each do |file|
   test_one_file "#{file}.jsn", "#{file}.smile"

--- a/test/test.sh
+++ b/test/test.sh
@@ -19,6 +19,6 @@ for i in 4k 64k; do
   test_file numbers-int-$i.jsn numbers-int-$i.smile
 done
 
-for i in 1 2; do
+for i in 1 2 3; do
     test_file test$i.jsn test$i.smile
 done


### PR DESCRIPTION
The offset was wrong, so this currently fails.

Relevant bit of the spec:

![image](https://user-images.githubusercontent.com/907370/84261035-05e76300-ab13-11ea-9eac-9a6e50186862.png)
